### PR TITLE
Enable Rubocop on circleci config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,12 +80,12 @@ jobs:
       - run: bundle exec rake db:create
       - run: bundle exec rake db:schema:load
 
-      # Rubocop
-      #   - run:
-      #     name: Rubocop
-      #     command: |
-      #        gem install rubocop
-      #        bundle exec rubocop
+     #Rubocop
+      - run:
+          name: Run Rubocop
+          command: |
+           gem install rubocop
+           bundle exec rubocop
 
       # Brakeman
       - run:


### PR DESCRIPTION
Fixes #82 

Rubocop errors were fixed in PR #130.  This PR enables Rubocop to run automatically in CircleCI.