### PR TITLE
Add platform x86_64-linux to Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.2.2'
 gem 'activerecord-import'
-gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 # Reduces boot times through caching; required in config/boot.rb
 # gem 'bootsnap', '>= 1.17.0', require: false
 gem 'bootsnap', '>= 1.1.0', require: false
@@ -29,6 +28,7 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 
 group :development do
+  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
   gem 'capistrano', '3.17.1'
   # gem 'capistrano3-puma', require: false
   gem 'capistrano-bundler', '~> 2.1', require: false
@@ -36,6 +36,7 @@ group :development do
   gem 'capistrano-rbenv', '~> 2.0' # required
   gem 'capistrano-rbenv-install', '~> 1.2.0'
   # gem 'capistrano-rvm', require: false
+  gem 'ed25519', '>= 1.2', '< 2.0'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'rb-readline'

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'activerecord-import'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'devise'
 gem 'dotenv-rails'
-# gem 'ed25519', '>= 1.2', '< 2.0'
 gem 'jbuilder', '~> 2.7'
 # Use Puma as the app server
 gem 'puma', '>= 6.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 
 group :development do
+  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
   gem 'capistrano', '3.17.1'
   # gem 'capistrano3-puma', require: false
   gem 'capistrano-bundler', '~> 2.1', require: false
@@ -34,6 +35,7 @@ group :development do
   gem 'capistrano-rbenv', '~> 2.0' # required
   gem 'capistrano-rbenv-install', '~> 1.2.0'
   # gem 'capistrano-rvm', require: false
+  # gem 'ed25519', '>= 1.2', '< 2.0'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'rb-readline'

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,13 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby '3.2.2'
 gem 'activerecord-import'
+gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
 # Reduces boot times through caching; required in config/boot.rb
 # gem 'bootsnap', '>= 1.17.0', require: false
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'devise'
 gem 'dotenv-rails'
+# gem 'ed25519', '>= 1.2', '< 2.0'
 gem 'jbuilder', '~> 2.7'
 # Use Puma as the app server
 gem 'puma', '>= 6.3.1'
@@ -27,7 +29,6 @@ gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 
 group :development do
-  gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
   gem 'capistrano', '3.17.1'
   # gem 'capistrano3-puma', require: false
   gem 'capistrano-bundler', '~> 2.1', require: false
@@ -35,7 +36,6 @@ group :development do
   gem 'capistrano-rbenv', '~> 2.0' # required
   gem 'capistrano-rbenv-install', '~> 1.2.0'
   # gem 'capistrano-rvm', require: false
-  # gem 'ed25519', '>= 1.2', '< 2.0'
   gem 'listen', '~> 3.3'
   gem 'rack-mini-profiler', '~> 2.0'
   gem 'rb-readline'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,7 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    bcrypt_pbkdf (1.1.0)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -191,6 +192,8 @@ GEM
     net-ssh (7.2.1)
     nio4r (2.7.0)
     nokogiri (1.16.2-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.2-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
@@ -334,6 +337,7 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.7.2-arm64-darwin)
+    sqlite3 (1.7.2-x86_64-darwin)
     sqlite3 (1.7.2-x86_64-linux)
     sshkit (1.22.0)
       mutex_m
@@ -380,10 +384,12 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   activerecord-import
+  bcrypt_pbkdf (>= 1.0, < 2.0)
   bootsnap (>= 1.1.0)
   brakeman
   bundler-audit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,12 +112,11 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.3)
-    coveralls (0.7.1)
-      multi_json (~> 1.3)
-      rest-client
-      simplecov (>= 0.7)
-      term-ansicolor
-      thor
+    coveralls_reborn (0.28.0)
+      simplecov (~> 0.22.0)
+      term-ansicolor (~> 1.7)
+      thor (~> 1.2)
+      tins (~> 1.32)
     crass (1.0.6)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
@@ -134,7 +133,6 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
     docile (1.4.0)
-    domain_name (0.6.20240107)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -192,7 +190,7 @@ GEM
       net-protocol
     net-ssh (7.2.1)
     nio4r (2.7.0)
-    nokogiri (1.16.2-x86_64-darwin)
+    nokogiri (1.16.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
@@ -335,7 +333,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.2-x86_64-darwin)
+    sqlite3 (1.7.2-arm64-darwin)
     sqlite3 (1.7.2-x86_64-linux)
     sshkit (1.22.0)
       mutex_m
@@ -381,7 +379,8 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
-  x86_64-darwin-21
+  arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   activerecord-import

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    ed25519 (1.3.0)
     erubi (1.12.0)
     execjs (2.9.1)
     factory_bot (6.4.6)
@@ -405,6 +406,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  ed25519 (>= 1.2, < 2.0)
   factory_bot_rails
   faker
   jbuilder (~> 2.7)


### PR DESCRIPTION
These changes in Gemfile.lock result from running the command `bundle lock --add-platform x86_64-linux` in the command line, as is needed to deploy the current qa branch.

This PR also adds two new gems to the development section of the Gemfile which are needed for deploy:  ed25519 and bcrypt_pbkdf.