### PR TITLE
updated gemfile for Darwin-21

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  x86_64-darwin-21
   x86_64-darwin-23
   x86_64-linux
 


### PR DESCRIPTION
I determined through various means that we still need this line in the gemfile.lock- there is a dependency that requires it. i think we need all these:My laptop uses darwin-23, so we need that. 

 arm64-darwin-22
  x86_64-darwin-21
  x86_64-darwin-23
  x86_64-linux

My laptop uses darwin-23, so we need that. Darwin 22 corresponds to macOS Ventura, which is version 13 of macOS. arm64 refers to Apple's M1 and M2 chips. 