### PR TITLE
155 - User Creation Bug Fix

### DIFF
--- a/db/migrate/20240404182059_remove_password_digest_from_users.rb
+++ b/db/migrate/20240404182059_remove_password_digest_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemovePasswordDigestFromUsers < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_231_212_172_527) do
+ActiveRecord::Schema.define(version: 20_240_404_182_059) do
   create_table 'add_data', force: :cascade do |t|
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
@@ -39,7 +39,6 @@ ActiveRecord::Schema.define(version: 20_231_212_172_527) do
 
   create_table 'users', force: :cascade do |t|
     t.string 'email', default: '', null: false
-    t.string 'password_digest'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
     t.string 'encrypted_password', default: '', null: false


### PR DESCRIPTION
Fixes #155 
## Remove Unnecessary password_digest Column from Users Table

This PR addresses issue #155 by resolving a conflict within our User model that hindered user creation and inspection in the console. Initially, our users table included both a password_digest column, intended for use with Rails' has_secure_password method, and an encrypted_password column, utilized by Devise for managing user authentication.

Given that our application exclusively uses Devise for authentication, the presence of the password_digest column was redundant and led to confusion within Rails about how user authentication should be handled. This redundancy was identified as the cause of our inability to create or inspect user records effectively in the development console.

Changes Introduced:

- A migration has been implemented to remove the password_digest column from the users table. This streamlines the user model by ensuring that only Devise's encrypted_password is used for authentication purposes.

Expected Outcomes:

- Elimination of the confusion Rails experienced when handling user creation and inspection, as now there's only one authentication mechanism in play.
- Simplification of the User model schema, aligning it more closely with our application's actual authentication workflow.
- Restoration of the ability to create and inspect User records in the console without encountering the previously reported issues.
