### PR TITLE
change number of tries before being locked out of account, from 20-10…

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -208,7 +208,7 @@ Devise.setup do |config|
 
   # Number of authentication tries before locking an account if lock_strategy
   # is failed attempts.
-  # config.maximum_attempts = 20
+  config.maximum_attempts = 10
 
   # Time interval to unlock the account if :time is enabled as unlock_strategy.
   # config.unlock_in = 1.hour
@@ -224,7 +224,7 @@ Devise.setup do |config|
   # Time interval you can reset your password with a reset password key.
   # Don't put a too small interval or your users won't have the time to
   # change their passwords.
-  config.reset_password_within = 6.hours
+  config.reset_password_within = 2.hours
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.


### PR DESCRIPTION
Small update to limit the "tries" user gets to enter password, before locking out. Default with devise is 20, changed to 10. Also limits the user to 2 hours to use their reset password token. 