### PR TITLE
LIBSTAFDIR-15 updated gemfile per warning in ruby 3.3.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'activerecord-import'
 # #added for ruby 3.4.0 as its not in standard library anymore
 gem 'bigdecimal'
 gem 'bootsnap', '>= 1.1.0', require: false
-#added for ruby 3.4.0 as its not in standard library anymore
+# added for ruby 3.4.0 as its not in standard library anymore
 gem 'csv'
 gem 'devise'
 gem 'dotenv-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,11 @@ gem 'actionpack', '6.1.7.8'
 gem 'activerecord-import'
 # Reduces boot times through caching; required in config/boot.rb
 # gem 'bootsnap', '>= 1.17.0', require: false
+# #added for ruby 3.4.0 as its not in standard library anymore
+gem 'bigdecimal'
 gem 'bootsnap', '>= 1.1.0', require: false
+#added for ruby 3.4.0 as its not in standard library anymore
+gem 'csv'
 gem 'devise'
 gem 'dotenv-rails'
 gem 'jbuilder', '~> 2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     base64 (0.2.0)
     bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.0)
+    bigdecimal (3.1.8)
     bindex (0.8.1)
     bootsnap (1.18.3)
       msgpack (~> 1.2)
@@ -119,6 +120,7 @@ GEM
       thor (~> 1.2)
       tins (~> 1.32)
     crass (1.0.6)
+    csv (3.3.0)
     database_cleaner (2.0.2)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.1.0)
@@ -399,6 +401,7 @@ DEPENDENCIES
   actionpack (= 6.1.7.8)
   activerecord-import
   bcrypt_pbkdf (>= 1.0, < 2.0)
+  bigdecimal
   bootsnap (>= 1.1.0)
   brakeman
   bundler-audit
@@ -411,6 +414,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   coffee-rails (~> 5.0)
   coveralls_reborn
+  csv
   database_cleaner
   devise
   dotenv-rails


### PR DESCRIPTION
Per warning on rake tasks, added items to gemfile. Warning:"Warning:[rake --tasks] /Users/lisa/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: /Users/lisa/.rbenv/versions/3.3.3/lib/ruby/3.3.0/bigdecimal.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of activesupport-6.1.7.8 to add bigdecimal into its gemspec.
/Users/lisa/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30: warning: /Users/lisa/.rbenv/versions/3.3.3/lib/ruby/3.3.0/csv.rb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of activesupport-6.1.7.8 to add csv into its gemspec."