### PR TITLE
Add missing babel dependencies to package.json

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-linux

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "staffdirectory",
   "private": true,
   "dependencies": {
+    "@babel/plugin-proposal-private-methods": "^7.18.6",
+    "@babel/plugin-proposal-private-property-in-object": "^7.18.6",
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",


### PR DESCRIPTION
We were having issues with the "delete" functionality not working when the app was run locally.  On investigation, it showed to be missing a couple Babel dependencies.  This PR puts those Babel dependencies into the package.json file.