### PR TITLE
update capistrano by removing line that locked version from deploy.rb

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,7 @@ gem 'turbolinks', '~> 5'
 
 group :development do
   gem 'bcrypt_pbkdf', '>= 1.0', '< 2.0'
-  gem 'capistrano', '3.18.1'
+  gem 'capistrano', '~> 3.19'
   # gem 'capistrano3-puma', require: false
   gem 'capistrano-bundler', '~> 2.1', require: false
   gem 'capistrano-rails', '~> 1.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
-    airbrussh (1.5.2)
+    airbrussh (1.5.3)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     base64 (0.2.0)
@@ -81,7 +81,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
     byebug (11.1.3)
-    capistrano (3.18.1)
+    capistrano (3.19.2)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -163,6 +163,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.6)
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -177,7 +178,6 @@ GEM
     mini_mime (1.1.5)
     minitest (5.25.4)
     msgpack (1.7.2)
-    mutex_m (0.2.0)
     mysql2 (0.5.6)
     net-imap (0.5.6)
       date
@@ -185,13 +185,13 @@ GEM
     net-pop (0.1.2)
     net-protocol (0.2.2)
       timeout
-    net-scp (4.0.0)
+    net-scp (4.1.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
-    net-ssh (7.2.3)
+    net-ssh (7.3.0)
     nio4r (2.7.4)
     nokogiri (1.16.7-arm64-darwin)
       racc (~> 1.4)
@@ -200,6 +200,7 @@ GEM
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    ostruct (0.6.1)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
@@ -344,12 +345,13 @@ GEM
     sqlite3 (1.7.3-arm64-darwin)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
-    sshkit (1.22.1)
+    sshkit (1.24.0)
       base64
-      mutex_m
+      logger
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
+      ostruct
     sync (0.5.0)
     term-ansicolor (1.8.0)
       tins (~> 1.0)
@@ -405,7 +407,7 @@ DEPENDENCIES
   brakeman
   bundler-audit
   byebug
-  capistrano (= 3.18.1)
+  capistrano (~> 3.19)
   capistrano-bundler (~> 2.1)
   capistrano-rails (~> 1.4)
   capistrano-rbenv (~> 2.0)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,3 @@
-lock '~> 3.18.1'
-
 set :application, 'staff-directory-23'
 set :repo_url, 'https://github.com/uclibs/staff-directory-23.git'
 


### PR DESCRIPTION
My deploy.rb file had the line to lock capistrano : '~> 3.18.1'. This updates to 3.19, then had to fix rubocop error