### PR TITLE
Libstaf1 5 update concurrent ruby

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Pin concurrent-ruby to 1.3.4 due to bug in later versions leading to "Logger::Severity" error.
+# Pin concurrent-ruby to avoid load-order regressions around Logger::Severity at boot.
 
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
@@ -11,7 +11,7 @@ gem 'activerecord-import'
 gem 'bigdecimal'
 gem 'bootsnap', '>= 1.1.0', require: false
 # added for ruby 3.4.0 as its not in standard library anymore
-gem 'concurrent-ruby', '1.3.4'
+gem 'concurrent-ruby', '1.3.6'
 gem 'csv'
 gem 'devise'
 gem 'dotenv-rails'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-# Pin concurrent-ruby to avoid load-order regressions around Logger::Severity at boot.
-
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
@@ -10,8 +8,7 @@ gem 'activerecord-import'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bigdecimal'
 gem 'bootsnap', '>= 1.1.0', require: false
-# added for ruby 3.4.0 as its not in standard library anymore
-gem 'concurrent-ruby', '1.3.6'
+gem 'concurrent-ruby', '1.3.6' # Use caution when updating; verify boot/deploy due to prior Logger::Severity issues.
 gem 'csv'
 gem 'devise'
 gem 'dotenv-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     coveralls_reborn (0.29.0)
       simplecov (~> 0.22.0)
@@ -523,7 +523,7 @@ DEPENDENCIES
   capistrano-rbenv-install (~> 1.2.0)
   capybara (>= 2.15)
   coffee-rails (~> 5.0)
-  concurrent-ruby (= 1.3.4)
+  concurrent-ruby (= 1.3.6)
   coveralls_reborn
   csv
   database_cleaner

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,7 +2,7 @@
 
 set :rails_env, :production
 set :bundle_without, %w[development test].join(' ')
-set :branch, 'LIBSTAF1-5-update-concurrent-ruby'
+set :branch, 'qa'
 set :default_env, path: '$PATH:/usr/local/bin'
 set :bundle_path, -> { shared_path.join('vendor/bundle') }
 set :rbenv_prefix,

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -2,7 +2,7 @@
 
 set :rails_env, :production
 set :bundle_without, %w[development test].join(' ')
-set :branch, 'qa'
+set :branch, 'LIBSTAF1-5-update-concurrent-ruby'
 set :default_env, path: '$PATH:/usr/local/bin'
 set :bundle_path, -> { shared_path.join('vendor/bundle') }
 set :rbenv_prefix,


### PR DESCRIPTION
## Summary

This PR updates concurrent-ruby from 1.3.4 to 1.3.6.

## Why

concurrent-ruby is used by Rails internals (via activesupport and other dependencies).

We previously pinned this gem due to a historical Logger::Severity boot/load-order issue. This update was validated to ensure that issue does not recur.

## Changes

- Updated gem pin:
  - Gemfile: concurrent-ruby 1.3.4 -> 1.3.6
- Updated lockfile:
  - Gemfile.lock: concurrent-ruby (1.3.4) -> (1.3.6)
  - DEPENDENCIES entry updated to concurrent-ruby (= 1.3.6)
- Added an inline caution note in Gemfile indicating this dependency should be updated carefully and verified during boot/deploy.

## Validation

- Local app boot verification passed (rails runner + Logger::Severity resolution)
- Test suite passed (bundle exec rspec, 129 examples, 0 failures)
- QA deploy passed (bundle exec cap qa deploy)

## Risk / Impact

- Scope is limited to one dependency bump (concurrent-ruby) plus its lockfile entry.
- Risk is low based on successful boot, tests, and QA deploy.
- Post-merge recommendation: standard smoke check of app startup and logs in QA/prod.
