### PR TITLE
Update shakapacker to v10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'rexml', '>= 3.3.2'
 gem 'sass-rails', '>= 6'
 gem 'sprockets-rails' # required for sass-rails on Rails 8 (Propshaft is default)
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'shakapacker', '9.5.0'
+gem 'shakapacker', '10.0.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 5.0'
 gem 'coveralls_reborn'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -406,7 +406,7 @@ GEM
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
     semantic_range (3.1.1)
-    shakapacker (9.5.0)
+    shakapacker (10.0.0)
       activesupport (>= 5.2)
       package_json
       rack-proxy (>= 0.6.1)
@@ -553,7 +553,7 @@ DEPENDENCIES
   rubocop-rspec (= 3.9.0)
   sass-rails (>= 6)
   selenium-webdriver
-  shakapacker (= 9.5.0)
+  shakapacker (= 10.0.0)
   shoulda-matchers (~> 5.0)
   simplecov
   simplecov-lcov

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "babel-plugin-macros": "^3.1.0",
     "compression-webpack-plugin": "11",
     "micromatch": "4.0.8",
-    "shakapacker": "9.5.0",
+    "shakapacker": "10.0.0",
     "stimulus": "^3.2.2",
     "terser-webpack-plugin": "5",
     "turbolinks": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2923,6 +2923,13 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+pack-config-diff@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/pack-config-diff/-/pack-config-diff-0.1.0.tgz#c15025e196ff85009806890cca0841e96aaa6a1b"
+  integrity sha512-gx60G4pnT4GFQ7WECdf7SCq9vdsvBhodLXXzwisy37/t0zkAZ3hMgLCdOGivudF1l0gcLZhIWVYreS89be15QA==
+  dependencies:
+    js-yaml "^4.1.0"
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -3318,12 +3325,13 @@ setprototypeof@1.2.0, setprototypeof@~1.2.0:
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
 
-shakapacker@9.5.0:
-  version "9.5.0"
-  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-9.5.0.tgz#761aee7f4c01d8a37b13d628968b6730897c967b"
-  integrity sha512-pTGHzHCc74CIoXeg8otCoBa8DjGWZUoYVKu9eyWwpdO9Jq6yHxSD9u5Qp36nXjC9jupd9gnfhCY5YHqkJHpfLA==
+shakapacker@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/shakapacker/-/shakapacker-10.0.0.tgz#870f823531c7362836975ab9bb16732234a580a0"
+  integrity sha512-bLKU/xGxIpC/oXvTBRLnpH6bjVK/wyYeWiwE35zd3xxbcg6WfbbQxls0L/AmO8p560RR2PgfR3QtHb7klBmu0A==
   dependencies:
     js-yaml "^4.1.0"
+    pack-config-diff "^0.1.0"
     path-complete-extname "^1.0.0"
     webpack-merge "^5.8.0"
     yargs "^17.7.2"


### PR DESCRIPTION
## Summary

This PR upgrades Shakapacker from 9.5.0 to 10.0.0 on both the Ruby and JavaScript sides so versions stay aligned.

## Changes

- Bumped Ruby gem:
  - shakapacker 9.5.0 -> 10.0.0
- Bumped JavaScript package:
  - shakapacker 9.5.0 -> 10.0.0
- Updated lockfiles:
  - Gemfile.lock
  - yarn.lock

## Why

- The project uses version consistency checks between gem and npm package.
- Shakapacker 10.0.0 is the current latest release.
- This keeps the stack current while preserving a minimal, focused change set.

## Compatibility / Dependencies

- No additional mandatory dependency changes were required for this upgrade in our environment.
- Existing webpack stack already satisfied Shakapacker 10 requirements.

## Validation

- Dependency resolution completed successfully:
  - bundle update shakapacker
  - yarn install
- Test suite passed:
  - bundle exec rspec (129 examples, 0 failures)
- Asset build passed:
  - yarn build (webpack compiled successfully)
- QA deploy passed:
  - bundle exec cap qa deploy

## Risk / Impact

- Scope is limited to Shakapacker version alignment and lockfile updates.
- Runtime risk appears low based on successful tests, build, and deploy verification.
- Standard post-merge smoke checks in QA/production are still recommended.
