### PR TITLE
Remove shoulda-matchers entirely

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ group :development, :test do
   gem 'rubocop-factory_bot', '2.28.0', require: false
   gem 'rubocop-rails', '2.34.3', require: false
   gem 'rubocop-rspec', '3.9.0', require: false
-  gem 'shoulda-matchers', '~> 5.0'
   gem 'simplecov', require: false
   gem 'simplecov-lcov', require: false
   # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -412,8 +412,6 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
-    shoulda-matchers (5.3.0)
-      activesupport (>= 5.2.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -554,7 +552,6 @@ DEPENDENCIES
   sass-rails (>= 6)
   selenium-webdriver
   shakapacker (= 10.0.0)
-  shoulda-matchers (~> 5.0)
   simplecov
   simplecov-lcov
   spring

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -75,13 +75,6 @@ RSpec.configure do |config|
   end
 end
 
-Shoulda::Matchers.configure do |config|
-  config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
-  end
-end
-
 require 'database_cleaner'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Summary

This PR removes the `shoulda-matchers` dependency from the test stack.

## Why

- The test suite does not currently use Shoulda matcher DSL (`validate_presence_of`, `belong_to`, etc.).
- Keeping an unused test dependency adds maintenance overhead and unnecessary upgrades.
- Removing it simplifies the test environment with no functional loss.

## Changes

- Removed gem declaration from `Gemfile` (`development,test` group).
- Removed `Shoulda::Matchers.configure` integration block from `spec/rails_helper.rb`.
- Updated `Gemfile.lock` to remove `shoulda-matchers` entries.

## Validation

- `bundle install` completed successfully.
- `bundle exec rspec` passed (`129 examples, 0 failures`).
- QA deploy passed (`bundle exec cap qa deploy`).

## Impact / Risk

- Scope is limited to test dependency cleanup.
- No production runtime impact.
- Low risk based on passing tests and successful deploy.
