### PR TITLE
Remove webdrivers entirely, relying on selenium-webdriver instead

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ group :test do
   gem 'capybara', '>= 2.15'
   gem 'database_cleaner'
   gem 'selenium-webdriver'
-  gem 'webdrivers', '~> 4.0', require: false
 end
 
 group :development, :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -476,10 +476,6 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
-    webdrivers (4.7.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (> 3.141, < 5.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -559,7 +555,6 @@ DEPENDENCIES
   sqlite3 (>= 2.1)
   turbolinks (~> 5)
   web-console (>= 4.1.0)
-  webdrivers (~> 4.0)
 
 RUBY VERSION
   ruby 3.4.7p58


### PR DESCRIPTION
## Summary

This PR removes webdrivers and uses selenium-webdriver directly for browser driver management.

### Why

- webdrivers constrains selenium-webdriver versions and works against staying current.
- Modern selenium-webdriver supports automatic driver management, so webdrivers is no longer needed.
- This simplifies the test stack and improves long-term maintainability.

## Changes

- Removed webdrivers from Gemfile test dependencies.
- Updated Gemfile.lock to remove webdrivers and related lock entries.
- Kept selenium-webdriver on the latest resolved version.

## Validation

- Tests pass: bundle exec rspec (129 examples, 0 failures).
- Deploy verified by branch owner: deploy succeeds.
- Dependency check: selenium-webdriver is up to date.

## Risk

Low.

- Scope is limited to test/dependency setup.
- App runtime behavior is unchanged.

## Rollback

If needed, re-add webdrivers in Gemfile and run bundle install to restore the previous setup.
