### PR TITLE
Remove unused compression-webpack dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "babel-loader": "10",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-macros": "^3.1.0",
-    "compression-webpack-plugin": "11",
     "micromatch": "4.0.8",
     "shakapacker": "10.0.0",
     "stimulus": "^3.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,14 +1878,6 @@ compressible@~2.0.18:
   dependencies:
     mime-db ">= 1.43.0 < 2"
 
-compression-webpack-plugin@11:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/compression-webpack-plugin/-/compression-webpack-plugin-11.1.0.tgz#ee340d2029cf99ccecdea9ad1410b377d15b48b3"
-  integrity sha512-zDOQYp10+upzLxW+VRSjEpRRwBXJdsb5lBMlRxx1g8hckIFBpe3DTI0en2w7h+beuq89576RVzfiXrkdPGrHhA==
-  dependencies:
-    schema-utils "^4.2.0"
-    serialize-javascript "^6.0.2"
-
 compression@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/compression/-/compression-1.8.1.tgz#4a45d909ac16509195a9a28bd91094889c180d79"
@@ -3266,7 +3258,7 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@6.0.2, serialize-javascript@^6.0.2:
+serialize-javascript@6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
   integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==


### PR DESCRIPTION
## Summary

This PR removes `compression-webpack-plugin` because it is installed but not used by the current webpack/shakapacker configuration.

## Changes

- Removed `compression-webpack-plugin` from `package.json` dependencies.
- Regenerated `yarn.lock` and removed the plugin lock entry.

## Why

- The plugin was not wired into `config/webpack/webpack.config.js`.
- Keeping unused build dependencies increases maintenance and update overhead.
- Removing it keeps the JS toolchain lean and intentional.

## Validation

- `yarn build` passes.
- `bundle exec rspec` passes (`129 examples, 0 failures`).
- QA deploy verified by branch owner.
- Smoke test verified by branch owner.

## Risk

Low.

- No runtime application logic was changed.
- Scope is limited to removing an unused build-time dependency.

## Rollback

- Re-add `compression-webpack-plugin` to `package.json` and run `yarn install`.
- If needed later, wire it explicitly in `config/webpack/webpack.config.js` before use.
