### PR TITLE
Remove redundant direct micromatch dependency (kept transitively)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "babel-loader": "10",
     "babel-plugin-dynamic-import-node": "^2.3.3",
     "babel-plugin-macros": "^3.1.0",
-    "micromatch": "4.0.8",
     "shakapacker": "10.0.0",
     "stimulus": "^3.2.2",
     "terser-webpack-plugin": "5",


### PR DESCRIPTION
## Summary

This PR removes the direct `micromatch` dependency from `package.json` after verifying it is redundant in this project.

## What Changed

- Removed direct dependency: `micromatch` from `package.json`.
- No other package changes were made.

## Why We Removed `micromatch`

- `micromatch` was listed directly in `package.json`, but is also pulled transitively by `webpack-dev-server` via `http-proxy-middleware`.
- Because the transitive dependency remains present and satisfies runtime/build needs, the direct declaration was redundant.
- Build and test validation confirmed behavior is unchanged.

## Why We Kept the Other Dependencies

The following dependencies were reviewed and intentionally kept:

- `babel-loader`
  - Required by Shakapacker’s Babel rule path when `javascript_transpiler: 'babel'`.
- `terser-webpack-plugin`
  - Required by Shakapacker’s webpack optimization path for JS minification.
- `webpack-assets-manifest`
  - Required by Shakapacker’s webpack plugin path for manifest generation.
- `webpack-subresource-integrity`
  - Kept as a Shakapacker peer dependency and for future SRI enablement.
  - Currently inactive in this app because `integrity.enabled: false` in `config/shakapacker.yml`.

## Why `yarn.lock` Did Not Change

- Removing direct `micromatch` did not alter lock resolution because `micromatch` is still required transitively by existing dependencies.
- Same package version remained in the resolved graph, so `yarn.lock` had no diff.

## Validation

- `yarn build` passes.
- `bundle exec rspec` passes (`129 examples, 0 failures`).

## Risk

Low.

- Scope is limited to removing a redundant direct dependency declaration.
- No application logic or webpack configuration changes.

## Rollback

- Re-add `"micromatch": "4.0.8"` to `package.json` and run `yarn install`.
