### PR TITLE
Libstaf1 24 update dependencies

### DIFF
--- a/.cursor/rules/no-push-without-explicit-request.mdc
+++ b/.cursor/rules/no-push-without-explicit-request.mdc
@@ -1,0 +1,41 @@
+---
+description: Never push to a remote unless the user explicitly requests it
+alwaysApply: true
+---
+
+# Never Push Without an Explicit Request
+
+**The user handles pushing.** By default, assume the user will push to the
+remote themselves. Do **not** run any command that publishes commits, branches,
+or tags to a remote unless the user has explicitly asked for that push in the
+current request.
+
+## Forbidden unless explicitly requested
+
+- `git push` (including `git push origin <branch>`, `-u`, `--tags`, `--follow-tags`)
+- `git push --force` / `--force-with-lease` (never run without an explicit request)
+- Creating remote refs via `git push origin <local>:<remote>`
+- Any tool/CLI that pushes (e.g. `gh release create`, `gh pr create` that pushes a branch)
+
+## Allowed without a push request
+
+Local-only work is fine: `git add`, `git commit`, `git tag` (local), `git branch`,
+`git merge`/`git rebase` on local branches, `git fetch`, `git pull` (read/update local only).
+
+## Required behavior
+
+- After committing locally, **stop** and tell the user the work is committed but
+  not pushed. Never push unless the current request asks for it explicitly.
+- "Explicit" means the user names the action this turn (e.g. "push this branch",
+  "push the tag", "open the PR"). General approval of a plan is **not** a push request.
+- If unsure whether something pushes to a remote, treat it as forbidden and ask first.
+
+<example>
+User: "Make a commit here."
+Assistant: Creates the commit locally, then reports it is committed but NOT pushed.
+</example>
+
+<example>
+User: "Push the branch and open the PR."
+Assistant: This explicitly requests the push, so pushing is allowed.
+</example>

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,7 +193,7 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    json (2.19.5)
+    json (2.19.7)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     listen (3.10.0)
@@ -218,7 +218,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     mize (0.6.1)
-    msgpack (1.8.0)
+    msgpack (1.8.1)
     mysql2 (0.5.7)
       bigdecimal
     net-imap (0.6.4)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "cross-spawn": "^7.0.3",
     "tslib": "^2.0.0",
     "micromatch": "4.0.8",
-    "braces": "3.0.3"
+    "braces": "3.0.3",
+    "qs": "6.15.2",
+    "uuid": "^11.1.1"
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4234,12 +4234,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:~6.14.0":
-  version: 6.14.2
-  resolution: "qs@npm:6.14.2"
+"qs@npm:6.15.2":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/646110124476fc9acf3c80994c8c3a0600cbad06a4ede1c9e93341006e8426d64e85e048baf8f0c4995f0f1bf0f37d1f3acc5ec1455850b81978792969a60ef6
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 
@@ -5181,12 +5181,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
+"uuid@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "uuid@npm:11.1.1"
   bin:
-    uuid: dist/bin/uuid
-  checksum: 10c0/bcbb807a917d374a49f475fae2e87fdca7da5e5530820ef53f65ba1d12131bd81a92ecf259cc7ce317cbe0f289e7d79fdfebcef9bfa3087c8c8a2fa304c9be54
+    uuid: dist/esm/bin/uuid
+  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves two moderate GitHub Dependabot/`yarn.lock` advisories and adds a repo guardrail. Both vulnerable packages are transitive dev dependencies of `webpack-dev-server`, pinned below their fixes, so they are forced to patched versions via yarn `resolutions`.

- **`qs` → 6.15.2** — fixes CVE-2026-8723 (GHSA-q8mj-m7cp-5q26), a remotely triggerable DoS where `qs.stringify` throws on `null`/`undefined` entries in comma-format arrays with `encodeValuesOnly`. Pulled in via `express`/`body-parser`.
- **`uuid` → ^11.1.1** — fixes CVE-2026-41907 (GHSA-w5hq-g745-h8pq), a missing buffer bounds check in `v3()`/`v5()`/`v6()` when `buf` is provided. Pulled in via `sockjs`.
- Incidental `bundle update`: `json` 2.19.5 → 2.19.7, `msgpack` 1.8.0 → 1.8.1.
- Adds `.cursor/rules/no-push-without-explicit-request.mdc`, an always-apply rule that forbids the agent from pushing to a remote unless explicitly requested.

## Testing

- `yarn npm audit --severity moderate` → No audit suggestions.
- Runtime smoke test: `qs` 6.15.2 and `uuid` 11.1.1 resolve; `uuid.v4()` works; the previously-crashing `qs.stringify({ a: [null, 'b'] }, { arrayFormat: 'comma', encodeValuesOnly: true })` now returns `a=,b`; `sockjs` and `express` load against the new versions.
- `bundle exec rspec` → 162 examples, 0 failures (after compiling test assets via `RAILS_ENV=test bin/shakapacker`).

## Notes

- `qs` and `uuid` are not part of the compiled application bundle; webpack compiles cleanly with the patched versions.
- Because the patched versions fall outside the transitive ranges (`qs@~6.14.0`, `uuid@^8.3.2`), `resolutions` overrides are required — a plain `yarn upgrade` will not pull them.
- `uuid` is a three-major jump (8 → 11); verified the only consumer (`sockjs`) uses the stable `v4()` API.